### PR TITLE
Prevent ambiguous reference

### DIFF
--- a/src/api/Godot.zig
+++ b/src/api/Godot.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 pub const Variant = @import("Variant.zig");
 pub usingnamespace @import("Vector.zig");
-pub const UtilityFunctions = @import("GodotCore").UtilityFunctions;
 const Core = @import("GodotCore"); //.GodotCore;
 const StringName = Core.StringName;
 const String = Core.String;


### PR DESCRIPTION
`Godot.UtilityFunctions` is an error because it is doubly exposed and ambiguous. Therefore, remove the `UtilityFunctions` variable from Godot.zig.

reproduction code

```
const std = @import("std");
const Godot = @import("godot");

const Self = @This();
pub usingnamespace Godot.Object;

base: Godot.Object,

pub fn init(self: *Self) void {
    std.log.info("init {s}", .{@typeName(@TypeOf(self))});
    _ = Godot.UtilityFunctions.abs(-1);
}
```

error message

```
src\Test.zig:11:14: error: ambiguous reference
    _ = Godot.UtilityFunctions.abs(-1);
        ~~~~~^~~~~~~~~~~~~~~~~
godot-zig\src\api\Godot.zig:4:5: note: declared here
pub const UtilityFunctions = @import("GodotCore").UtilityFunctions;
~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gen\api\GodotCore.zig:3:5: note: declared here
pub const UtilityFunctions = @import("UtilityFunctions.zig");
~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    create__anon_39314: godot-zig\src\api\Godot.zig:134:13
    create_instance_bind: godot-zig\src\api\Godot.zig:340:31
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```
