### PR TITLE
Prevent ambiguous reference

### DIFF
--- a/src/api/Godot.zig
+++ b/src/api/Godot.zig
@@ -6,7 +6,7 @@ const StringName = Core.StringName;
 const String = Core.String;
 pub usingnamespace Core;
 pub usingnamespace Core.C;
-pub var general_allocator: std.mem.Allocator = undefined;
+var general_allocator: std.mem.Allocator = undefined;
 
 const builtin = @import("builtin");
 
@@ -191,7 +191,7 @@ pub fn registerPlugin(p_get_proc_address: Core.C.GDExtensionInterfaceGetProcAddr
     r_initialization.*.deinitialize = T.deinitializeLevel;
     r_initialization.*.minimum_initialization_level = Core.C.GDEXTENSION_INITIALIZATION_SCENE;
     general_allocator = allocator;
-    Core.initCore(p_get_proc_address.?, p_library) catch unreachable;
+    Core.initCore(p_get_proc_address.?, p_library, general_allocator) catch unreachable;
     return 1;
 }
 


### PR DESCRIPTION
```
godot-zig\src\api\Godot.zig:194:9: error: expected 3 argument(s), found 2
    Core.initCore(p_get_proc_address.?, p_library) catch unreachable;
    ~~~~^~~~~~~~~
gen\api\GodotCore.zig:1065:5: note: function declared here
pub fn initCore(getProcAddress:std.meta.Child(Godot.GDExtensionInterfaceGetProcAddress), library: Godot.GDExtensionClassLibraryPtr, allocator_: std.mem.Allocator) !void {
~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    my_extension_init: src\Entry.zig:10:17
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
src\SpriteNode.zig:24:52: error: ambiguous reference
    self.sprites = std.ArrayList(Sprite).init(Godot.general_allocator);
                                              ~~~~~^~~~~~~~~~~~~~~~~~
godot-zig\src\api\Godot.zig:9:5: note: declared here
pub var general_allocator: std.mem.Allocator = undefined;
~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gen\api\GodotCore.zig:911:5: note: declared here
pub var general_allocator: std.mem.Allocator = undefined;
~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: the following command failed with 2 compilation errors:
```