### PR TITLE
Fix compile error when registered methods return i64 and f64

### DIFF
--- a/src/api/Godot.zig
+++ b/src/api/Godot.zig
@@ -465,7 +465,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
                 if (ReturnType == void or ReturnType == null) {
                     @call(.auto, method, .{});
                 } else {
-                    @as(*ReturnType.?, @ptrCast(p_return)).* = @call(.auto, method, .{});
+                    @as(*ReturnType.?, @ptrCast(@alignCast(p_return))).* = @call(.auto, method, .{});
                 }
             } else {
                 var args: std.meta.ArgsTuple(MethodType) = undefined;
@@ -476,7 +476,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
                 if (ReturnType == void or ReturnType == null) {
                     @call(.auto, method, args);
                 } else {
-                    @as(*ReturnType.?, @ptrCast(p_return)).* = @call(.auto, method, args);
+                    @as(*ReturnType.?, @ptrCast(@alignCast(p_return))).* = @call(.auto, method, args);
                 }
             }
         }


### PR DESCRIPTION

Registering a method that returns i64 or f64 with registerMethod as follows will result in a compile error. We have modified it so that it can be registered for this purpose.

```zig
const std = @import("std");
const Godot = @import("godot");
const String = Godot.String;
const Variant = Godot.Variant;

const Self = @This();
pub usingnamespace Godot.RefCounted;
base: Godot.RefCounted,

pub fn _bind_methods() void {
    Godot.registerMethod(Self, "add10");
    Godot.registerMethod(Self, "sub10");
}

pub fn init(self: *Self) void {
    std.log.info("init {s}", .{@typeName(@TypeOf(self))});
}

pub fn deinit(self: *Self) void {
    std.log.info("deinit {s}", .{@typeName(@TypeOf(self))});
}

pub fn add10(self: *Self, val: u64) u64 {
    std.log.info("add10 {s}", .{@typeName(@TypeOf(self))});
    return val + 10;
}

pub fn sub10(self: *Self, val: f64) f64 {
    std.log.info("add10 {s}", .{@typeName(@TypeOf(self))});
    return val - 10;
}
```

```
install
└─ install example
   └─ zig build-lib example Debug native 2 errors
godot-zig\src\api\Godot.zig:479:40: error: @ptrCast increases pointer alignment
                    @as(*ReturnType.?, @ptrCast(p_return)).* = @call(.auto, method, args);
                                       ^~~~~~~~~~~~~~~~~~
godot-zig\src\api\Godot.zig:479:49: note: '?*anyopaque' has alignment '1'
                    @as(*ReturnType.?, @ptrCast(p_return)).* = @call(.auto, method, args);
                                                ^~~~~~~~
godot-zig\src\api\Godot.zig:479:40: note: '*u64' has alignment '8'
godot-zig\src\api\Godot.zig:479:40: note: use @alignCast to assert pointer alignment
referenced by:
    registerMethod__anon_41473: godot-zig\src\api\Godot.zig:527:37
    _bind_methods: src\Custom.zig:11:25
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
godot-zig\src\api\Godot.zig:479:40: error: @ptrCast increases pointer alignment
                    @as(*ReturnType.?, @ptrCast(p_return)).* = @call(.auto, method, args);
                                       ^~~~~~~~~~~~~~~~~~
godot-zig\src\api\Godot.zig:479:49: note: '?*anyopaque' has alignment '1'
                    @as(*ReturnType.?, @ptrCast(p_return)).* = @call(.auto, method, args);
                                                ^~~~~~~~
godot-zig\src\api\Godot.zig:479:40: note: '*f64' has alignment '8'
godot-zig\src\api\Godot.zig:479:40: note: use @alignCast to assert pointer alignment
```