### PR TITLE
switch type info enum variants

### DIFF
--- a/binding_generator/main.zig
+++ b/binding_generator/main.zig
@@ -408,9 +408,9 @@ fn generateProc(code_builder: anytype, fn_node: anytype, allocator: mem.Allocato
         try code_builder.printLine(1, "var args:[{d}]Godot.GDExtensionConstTypePtr = undefined;", .{args.items.len});
         for (0..args.items.len) |i| {
             if (isEngineClass(arg_types.items[i])) {
-                try code_builder.printLine(1, "if(@typeInfo(@TypeOf({1s})) == .Struct) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s})); }}", .{ i, args.items[i] });
-                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .Optional) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s}.?)); }}", .{ i, args.items[i] });
-                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .Pointer) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr({1s})); }}", .{ i, args.items[i] });
+                try code_builder.printLine(1, "if(@typeInfo(@TypeOf({1s})) == .@\"struct\") {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s})); }}", .{ i, args.items[i] });
+                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .optional) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s}.?)); }}", .{ i, args.items[i] });
+                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .pointer) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr({1s})); }}", .{ i, args.items[i] });
                 try code_builder.printLine(1, "else {{ args[{0d}] = null; }}", .{i});
             } else {
                 if ((proc_type != .Constructor or !isStringType(class_name)) and (isStringType(arg_types.items[i]))) {

--- a/src/api/Godot.zig
+++ b/src/api/Godot.zig
@@ -92,10 +92,10 @@ pub fn free(ptr: ?*anyopaque) void {
 
 pub fn getGodotObjectPtr(inst: anytype) *const ?*anyopaque {
     const typeInfo = @typeInfo(@TypeOf(inst));
-    if (typeInfo != .Pointer) {
+    if (typeInfo != .pointer) {
         @compileError("pointer required");
     }
-    const T = typeInfo.Pointer.child;
+    const T = typeInfo.pointer.child;
     if (@hasField(T, "godot_object")) {
         return &inst.godot_object;
     } else if (@hasField(T, "base")) {
@@ -104,7 +104,7 @@ pub fn getGodotObjectPtr(inst: anytype) *const ?*anyopaque {
 }
 
 pub fn cast(comptime T: type, inst: anytype) ?T {
-    if (@typeInfo(@TypeOf(inst)) == .Optional) {
+    if (@typeInfo(@TypeOf(inst)) == .optional) {
         if (inst) |i| {
             return .{ .godot_object = i.godot_object };
         } else {
@@ -394,8 +394,8 @@ pub fn registerClass(comptime T: type) void {
 
 pub fn MethodBinderT(comptime MethodType: type) type {
     return struct {
-        const ReturnType = @typeInfo(MethodType).Fn.return_type;
-        const ArgCount = @typeInfo(MethodType).Fn.params.len;
+        const ReturnType = @typeInfo(MethodType).@"fn".return_type;
+        const ArgCount = @typeInfo(MethodType).@"fn".params.len;
         const ArgsTuple = std.meta.fields(std.meta.ArgsTuple(MethodType));
         var arg_properties: [ArgCount + 1]Core.C.GDExtensionPropertyInfo = undefined;
         var arg_metadata: [ArgCount + 1]Core.C.GDExtensionClassMethodArgumentMetadata = undefined;
@@ -432,7 +432,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
 
         fn ptrToArg(comptime T: type, p_arg: Core.C.GDExtensionConstTypePtr) T {
             switch (@typeInfo(T)) {
-                // .Pointer => |pointer| {
+                // .pointer => |pointer| {
                 //     const ObjectType = pointer.child;
                 //     const ObjectTypeName = comptime getBaseName(@typeName(ObjectType));
                 //     const callbacks = @field(ObjectType, "callbacks_" ++ ObjectTypeName);
@@ -443,7 +443,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
                 //         return @ptrCast(@alignCast(Core.objectGetInstanceBinding(p_arg, Core.p_library, @ptrCast(&callbacks))));
                 //     }
                 // },
-                .Struct => {
+                .@"struct" => {
                     if (@hasDecl(T, "reference") and @hasDecl(T, "unreference")) { //RefCounted
                         const obj = Core.refGetObject(p_arg);
                         return .{ .godot_object = obj };
@@ -571,7 +571,7 @@ pub fn registerSignal(comptime T: type, comptime signal_name: [:0]const u8, argu
 }
 
 pub fn connect(godot_object: anytype, signal_name: [:0]const u8, instance: anytype, comptime method_name: [:0]const u8) void {
-    if (@typeInfo(@TypeOf(instance)) != .Pointer) {
+    if (@typeInfo(@TypeOf(instance)) != .pointer) {
         @compileError("pointer type expected for parameter 'instance'");
     }
     registerMethod(std.meta.Child(@TypeOf(instance)), method_name);

--- a/src/api/Variant.zig
+++ b/src/api/Variant.zig
@@ -128,14 +128,14 @@ fn getByGodotType(comptime T: type) Type {
 fn getChildTypeOrSelf(comptime T: type) type {
     const typeInfo = @typeInfo(T);
     return switch (typeInfo) {
-        .Pointer => |info| info.child,
-        .Optional => |info| info.child,
+        .pointer => |info| info.child,
+        .optional => |info| info.child,
         else => T,
     };
 }
 pub fn getVariantType(comptime T: type) Type {
     const typeInfo = @typeInfo(T);
-    if (typeInfo == .Pointer and @typeInfo(typeInfo.Pointer.child) != .Struct) {
+    if (typeInfo == .pointer and @typeInfo(typeInfo.pointer.child) != .@"struct") {
         @compileError("Init Variant from " ++ @typeName(T) ++ " is not supported");
     }
     const RT = getChildTypeOrSelf(T);
@@ -143,11 +143,11 @@ pub fn getVariantType(comptime T: type) Type {
     const ret = comptime getByGodotType(RT);
     if (ret == Godot.GDEXTENSION_VARIANT_TYPE_NIL) {
         const ret1 = switch (@typeInfo(RT)) {
-            .Struct => Godot.GDEXTENSION_VARIANT_TYPE_OBJECT,
-            .Bool => Godot.GDEXTENSION_VARIANT_TYPE_BOOL,
-            .Int, .ComptimeInt => Godot.GDEXTENSION_VARIANT_TYPE_INT,
-            .Float, .ComptimeFloat => Godot.GDEXTENSION_VARIANT_TYPE_FLOAT,
-            .Void => Godot.GDEXTENSION_VARIANT_TYPE_NIL,
+            .@"struct" => Godot.GDEXTENSION_VARIANT_TYPE_OBJECT,
+            .bool => Godot.GDEXTENSION_VARIANT_TYPE_BOOL,
+            .int, .comptime_int => Godot.GDEXTENSION_VARIANT_TYPE_INT,
+            .float, .comptime_float => Godot.GDEXTENSION_VARIANT_TYPE_FLOAT,
+            .void => Godot.GDEXTENSION_VARIANT_TYPE_NIL,
             else => @compileError("Cannot construct variant from " ++ @typeName(T)),
         };
         return ret1;
@@ -178,7 +178,7 @@ pub fn as(self_const: Self, comptime T: type) T {
         var obj: ?*anyopaque = null;
         to_type[Godot.GDEXTENSION_VARIANT_TYPE_OBJECT].?(@ptrCast(&obj), @ptrCast(&self.value));
         const godotObj: *Godot.Object = @ptrCast(@alignCast(Godot.getObjectInstanceBinding(obj)));
-        const RealType = @typeInfo(T).Pointer.child;
+        const RealType = @typeInfo(T).pointer.child;
         if (RealType == Godot.Object) {
             return godotObj;
         } else {


### PR DESCRIPTION
for running with latest zig dev changes. (not sure if already needed, just opening PR in case it can save someone else from doing those changes), only tested the godot-zig-example with it.