### PR TITLE
Allow using as a Zig dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
-const ResolvedTarget = std.Build.ResolvedTarget;
+const Build = std.Build;
+const ResolvedTarget = Build.ResolvedTarget;
 const OptimizeMode = std.builtin.OptimizeMode;
-const Module = std.Build.Module;
+const Module = Build.Module;
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
@@ -16,7 +17,8 @@ pub fn createModule(b: *std.Build, target: ResolvedTarget, optimize: OptimizeMod
     const precision = b.option([]const u8, "precision", "Floating point precision, either `float` or `double` [default: `float`]") orelse "float";
     const arch = b.option([]const u8, "arch", "32") orelse "64";
     const gen_path = b.option([]const u8, "output", "Path to save auto-generated files [default: `./gen/api`]") orelse "./gen/api";
-    const dump_path = b.pathJoin(&.{ thisDirAbs(b.allocator), "src", "api" });
+
+    const dump_path = b.pathJoin(&.{ thisDirAbs(b), "src", "api" });
 
     const dump_cmd = b.addSystemCommand(&.{
         godot_path, "--dump-extension-api", "--dump-gdextension-interface", "--headless",
@@ -24,13 +26,24 @@ pub fn createModule(b: *std.Build, target: ResolvedTarget, optimize: OptimizeMod
 
     std.fs.cwd().makePath(gen_path) catch unreachable;
 
-    dump_cmd.setCwd(.{ .cwd_relative = dump_path });
+    const is_dependency = b.dep_prefix.len > 0;
+    if (!is_dependency) {
+        dump_cmd.setCwd(.{ .cwd_relative = dump_path });
+    }
+
     const dump_step = b.step("dump", "dump api");
     dump_step.dependOn(&dump_cmd.step);
 
-    const binding_generator = b.addExecutable(.{ .name = "binding_generator", .target = target, .root_source_file = b.path(b.pathJoin(&.{ thisDir(b.allocator), "binding_generator/main.zig" })) });
+    const binding_generator_path = b.pathJoin(&.{ thisDir(b), "binding_generator/main.zig" });
+    const binding_generator = b.addExecutable(
+        .{
+            .name = "binding_generator",
+            .target = target,
+            .root_source_file = b.path(binding_generator_path),
+        },
+    );
     binding_generator.addIncludePath(b.path(gen_path));
-    binding_generator.addIncludePath(b.path(b.pathJoin(&.{ thisDir(b.allocator), "src", "api" })));
+    binding_generator.addIncludePath(b.path(b.pathJoin(&.{ thisDir(b), "src", "api" })));
     binding_generator.step.dependOn(dump_step);
 
     const generate_binding = std.Build.Step.Run.create(b, "bind_godot");
@@ -41,7 +54,7 @@ pub fn createModule(b: *std.Build, target: ResolvedTarget, optimize: OptimizeMod
     bind_step.dependOn(&generate_binding.step);
 
     const module = b.addModule("godot", .{
-        .root_source_file = b.path(b.pathJoin(&.{ thisDir(b.allocator), "src", "api", "Godot.zig" })),
+        .root_source_file = b.path(b.pathJoin(&.{ thisDir(b), "src", "api", "Godot.zig" })),
         .target = target,
         .optimize = optimize,
     });
@@ -61,12 +74,13 @@ pub fn createModule(b: *std.Build, target: ResolvedTarget, optimize: OptimizeMod
     return module;
 }
 
-inline fn thisDirAbs(allocator: std.mem.Allocator) []const u8 {
-    const abspath = comptime std.fs.path.dirname(@src().file) orelse ".";
-    return std.fs.path.relative(allocator, "./", abspath) catch unreachable;
+inline fn thisDirAbs(b: *Build) []const u8 {
+    const is_dependency = b.dep_prefix.len > 0;
+    const abspath = if (is_dependency) "." else comptime std.fs.path.dirname(@src().file) orelse ".";
+    return std.fs.path.relative(b.allocator, "./", abspath) catch unreachable;
 }
 
-inline fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    const abspath = thisDirAbs(allocator);
-    return std.fs.path.relative(allocator, "./", abspath) catch unreachable;
+inline fn thisDir(b: *Build) []const u8 {
+    const abspath = thisDirAbs(b);
+    return std.fs.path.relative(b.allocator, "./", abspath) catch unreachable;
 }

--- a/build.zig
+++ b/build.zig
@@ -9,11 +9,11 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const godot_path = b.option([]const u8, "godot_path", "Path to Godot binary [default: `godot`]") orelse "godot";
 
-    const module = try createModule(b, target, optimize, godot_path);
+    const module = createModule(b, target, optimize, godot_path);
     defer _ = module;
 }
 
-pub fn createModule(b: *std.Build, target: ResolvedTarget, optimize: OptimizeMode, godot_path: []const u8) !*Module {
+pub fn createModule(b: *std.Build, target: ResolvedTarget, optimize: OptimizeMode, godot_path: []const u8) *Module {
     const precision = b.option([]const u8, "precision", "Floating point precision, either `float` or `double` [default: `float`]") orelse "float";
     const arch = b.option([]const u8, "arch", "32") orelse "64";
     const gen_path = b.option([]const u8, "output", "Path to save auto-generated files [default: `./gen/api`]") orelse "./gen/api";

--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,18 @@
 const std = @import("std");
+const ResolvedTarget = std.Build.ResolvedTarget;
+const OptimizeMode = std.builtin.OptimizeMode;
+const Module = std.Build.Module;
 
-pub fn build(_: *std.Build) void {}
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const godot_path = b.option([]const u8, "godot_path", "Path to Godot binary [default: `godot`]") orelse "godot";
 
-pub fn createModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, godot_path: []const u8) *std.Build.Module {
+    const module = try createModule(b, target, optimize, godot_path);
+    defer _ = module;
+}
+
+pub fn createModule(b: *std.Build, target: ResolvedTarget, optimize: OptimizeMode, godot_path: []const u8) !*Module {
     const precision = b.option([]const u8, "precision", "Floating point precision, either `float` or `double` [default: `float`]") orelse "float";
     const arch = b.option([]const u8, "arch", "32") orelse "64";
     const gen_path = b.option([]const u8, "output", "Path to save auto-generated files [default: `./gen/api`]") orelse "./gen/api";


### PR DESCRIPTION
Makes it possible to use `godot-zig` as a dependency of your own Zig project. There will be an associated PR for `godot-zig-examples` that you can use to test this out which I will link below. 

# Why do this?

It seems to be discouraged to use git submodules for package dependences in Zig projects. And in fact, the Zig package manager does not support git submodules at all. 

Consuming `godot-zig` as a Zig dependency is much more in line with what Zig programmers expect. 

# Note

This PR is backwards compatible, as `createModule` still works as before. 