### PR TITLE
Fix Windows build

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+**/project/lib/


### PR DESCRIPTION
Converts temporary path used in `run_binding_generator` to a relative path to fix the following error on Windows:

```
install
└─ install godot
   └─ zig build-lib godot Debug native
      └─ run_binding_generator (C:\Users\Simon\Projects\godot-zig\.zig-cache\tmp\5d7b600bcecc0201) failure
error: unable to make path 'C:\Users\Simon\Projects\godot-zig\.zig-cache\o\784867c7db2e95aa8b9b7753b6039180\C:\Users\Simon\Projects\godot-zig\.zig-cache\tmp\5d7b600bcecc0201': BadPathName
Build Summary: 6/12 steps succeeded; 1 failed (disable with --summary none)
install transitive failure
└─ install godot transitive failure
   └─ zig build-lib godot Debug native transitive failure
      ├─ run_binding_generator (C:\Users\Simon\Projects\godot-zig\.zig-cache\tmp\5d7b600bcecc0201) failure
      ├─ run_binding_generator (C:\Users\Simon\Projects\godot-zig\.zig-cache\tmp\5d7b600bcecc0201) (+1 more reused dependencies)
      ├─ run_binding_generator (C:\Users\Simon\Projects\godot-zig\.zig-cache\tmp\5d7b600bcecc0201) (+1 more reused dependencies)
      └─ bindgen transitive failure
         └─ install generated/ transitive failure
            └─ run_binding_generator (C:\Users\Simon\Projects\godot-zig\.zig-cache\tmp\5d7b600bcecc0201) (+1 more reused dependencies)
```

I assume this should still work on MacOS/Linux. 