### PR TITLE
Update bindings to adhere to Zig Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # godot-zig
 
-A WIP Zig bindings for Godot 4.  
-Features are being gradually added to meet the needs of a demo game.  
-Bugs and missing features are expected until a stable version finally released.  
+A WIP Zig bindings for Godot 4.
+Features are being gradually added to meet the needs of a demo game.
+Bugs and missing features are expected until a stable version finally released.
 Issue report, feature request and pull request are all welcome.
 
 ## Prerequisites
@@ -28,19 +28,19 @@ base: Base,
 sprite: Godot.Sprite2D,
 
 pub fn _enter_tree(self: *Self) void {
-    if (Godot.Engine.getSingleton().is_editor_hint()) return;
+    if (Godot.Engine.getSingleton().isEditorHint()) return;
 
     var normal_btn = Godot.initButton();
     self.add_child(normal_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    normal_btn.set_position(Vec2.new(100, 20), false);
-    normal_btn.set_size(Vec2.new(100, 50), false);
-    normal_btn.set_text("Press Me");
+    normal_btn.setPosition(Vec2.new(100, 20), false);
+    normal_btn.setSize(Vec2.new(100, 50), false);
+    normal_btn.setText("Press Me");
 
     var toggle_btn = Godot.initCheckBox();
     self.add_child(toggle_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    toggle_btn.set_position(Vec2.new(320, 20), false);
-    toggle_btn.set_size(Vec2.new(100, 50), false);
-    toggle_btn.set_text("Toggle Me");
+    toggle_btn.setPosition(Vec2.new(320, 20), false);
+    toggle_btn.setSize(Vec2.new(100, 50), false);
+    toggle_btn.setText("Toggle Me");
 
     Godot.connect(toggle_btn, "toggled", self, "on_toggled");
     Godot.connect(normal_btn, "pressed", self, "on_pressed");
@@ -51,10 +51,10 @@ pub fn _enter_tree(self: *Self) void {
     if (texture) |tex| {
         defer _ = Godot.unreference(tex);
         self.sprite = Godot.initSprite2D();
-        self.sprite.set_texture(tex);
-        self.sprite.set_position(Vec2.new(400, 300));
-        self.sprite.set_scale(Vec2.new(0.6, 0.6));
-        self.add_child(self.sprite, false, Godot.Node.INTERNAL_MODE_DISABLED);
+        self.sprite.setTexture(tex);
+        self.sprite.setPosition(Vec2.new(400, 300));
+        self.sprite.setScale(Vec2.new(0.6, 0.6));
+        self.addChild(self.sprite, false, Godot.Node.INTERNAL_MODE_DISABLED);
     }
 }
 

--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,9 @@ pub fn build(b: *std.Build) !void {
     binding_generator_step.dependOn(&binding_generator.step);
     b.installArtifact(binding_generator);
 
+    const lib_case = b.dependency("case", .{});
+    binding_generator.root_module.addImport("case", lib_case.module("case"));
+
     const bindgen = build_bindgen(b, gdextension.iface_headers.dirname(), binding_generator, precision, arch);
 
     const lib = b.addSharedLibrary(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,12 @@
 .{
     .name = "godot",
     .version = "0.0.0-dev",
+    .dependencies = .{
+        .case = .{
+            .url = "git+https://github.com/travisstaloch/case#698a01886de891c03434f34e6bca95546026eb0f",
+            .hash = "12207c971fe9b4d6430503d3a4d00c6296f52b52da47c11cb8e37706e86c3ffee49e",
+        },
+    },
     .minimum_zig_version = "0.13.0",
 
     .paths = .{

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+**/project/lib/

--- a/examples/basic/src/root.zig
+++ b/examples/basic/src/root.zig
@@ -9,7 +9,7 @@ base: Base,
 sprite: Godot.Sprite2D,
 
 pub fn _enter_tree(self: *Self) void {
-    if (Godot.Engine.getSingleton().is_editor_hint()) return;
+    if (Godot.Engine.getSingleton().isEditorHint()) return;
 
     var normal_btn = Godot.initButton();
     self.add_child(normal_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);

--- a/examples/with_project/src/ExampleNode.zig
+++ b/examples/with_project/src/ExampleNode.zig
@@ -53,8 +53,8 @@ pub fn on_item_focused(self: *Self, idx: i64) void {
         inline 0...Examples.len - 1 => |i| {
             const n = Godot.create(Examples[i].T) catch unreachable;
             self.example_node = Godot.cast(Godot.Node, n.base);
-            self.panel.add_child(self.example_node, false, Godot.Node.INTERNAL_MODE_DISABLED);
-            self.panel.grab_focus();
+            self.panel.addChild(self.example_node, false, Godot.Node.INTERNAL_MODE_DISABLED);
+            self.panel.grabFocus();
         },
         else => {},
     }
@@ -70,19 +70,19 @@ pub fn _enter_tree(self: *Self) void {
     self.property1 = Vec3.new(111, 111, 111);
     self.property2 = Vec3.new(222, 222, 222);
 
-    if (Godot.Engine.getSingleton().is_editor_hint()) return;
+    if (Godot.Engine.getSingleton().isEditorHint()) return;
 
-    const window_size = self.get_tree().?.get_root().?.get_size();
+    const window_size = self.getTree().?.getRoot().?.getSize();
     var sp = Godot.initHSplitContainer();
-    sp.set_h_size_flags(Godot.Control.SIZE_EXPAND_FILL);
-    sp.set_v_size_flags(Godot.Control.SIZE_EXPAND_FILL);
-    sp.set_split_offset(@intFromFloat(@as(f32, @floatFromInt(window_size.x)) * 0.2));
-    sp.set_anchors_preset(Godot.Control.PRESET_FULL_RECT, false);
+    sp.setHSizeFlags(Godot.Control.SIZE_EXPAND_FILL);
+    sp.setVSizeFlags(Godot.Control.SIZE_EXPAND_FILL);
+    sp.setSplitOffset(@intFromFloat(@as(f32, @floatFromInt(window_size.x)) * 0.2));
+    sp.setAnchorsPreset(Godot.Control.PRESET_FULL_RECT, false);
     var itemList = Godot.initItemList();
     inline for (0..Examples.len) |i| {
-        _ = itemList.add_item(Examples[i].name, null, true);
+        _ = itemList.addItem(Examples[i].name, null, true);
     }
-    var timer = self.get_tree().?.create_timer(1.0, true, false, false);
+    var timer = self.getTree().?.createTimer(1.0, true, false, false);
     defer _ = timer.?.unreference();
 
     Godot.connect(timer.?, "timeout", self, "on_timeout");
@@ -90,12 +90,12 @@ pub fn _enter_tree(self: *Self) void {
 
     Godot.connect(itemList, "item_selected", self, "on_item_focused");
     self.panel = Godot.initPanelContainer();
-    self.panel.set_h_size_flags(Godot.Control.SIZE_FILL);
-    self.panel.set_v_size_flags(Godot.Control.SIZE_FILL);
-    self.panel.set_focus_mode(Godot.Control.FOCUS_ALL);
-    sp.add_child(itemList, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    sp.add_child(self.panel, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    self.base.add_child(sp, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    self.panel.setHSizeFlags(Godot.Control.SIZE_FILL);
+    self.panel.setVSizeFlags(Godot.Control.SIZE_FILL);
+    self.panel.setFocusMode(Godot.Control.FOCUS_ALL);
+    sp.addChild(itemList, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    sp.addChild(self.panel, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    self.base.addChild(sp, false, Godot.Node.INTERNAL_MODE_DISABLED);
 }
 
 pub fn _exit_tree(self: *Self) void {
@@ -104,8 +104,8 @@ pub fn _exit_tree(self: *Self) void {
 
 pub fn _notification(self: *Self, what: i32) void {
     if (what == Godot.Node.NOTIFICATION_WM_CLOSE_REQUEST) {
-        if (!Godot.Engine.getSingleton().is_editor_hint()) {
-            self.get_tree().?.quit(0);
+        if (!Godot.Engine.getSingleton().isEditorHint()) {
+            self.getTree().?.quit(0);
         }
     }
 }
@@ -122,9 +122,9 @@ pub fn _get_property_list(_: *Self) []const Godot.PropertyInfo {
 }
 
 pub fn _property_can_revert(_: *Self, name: Godot.StringName) bool {
-    if (name.casecmp_to(property1_name) == 0) {
+    if (name.casecmpTo(property1_name) == 0) {
         return true;
-    } else if (name.casecmp_to(property2_name) == 0) {
+    } else if (name.casecmpTo(property2_name) == 0) {
         return true;
     }
 
@@ -132,10 +132,10 @@ pub fn _property_can_revert(_: *Self, name: Godot.StringName) bool {
 }
 
 pub fn _property_get_revert(_: *Self, name: Godot.StringName, value: *Godot.Variant) bool {
-    if (name.casecmp_to(property1_name) == 0) {
+    if (name.casecmpTo(property1_name) == 0) {
         value.* = Godot.Variant.initFrom(Vec3.new(42, 42, 42));
         return true;
-    } else if (name.casecmp_to(property2_name) == 0) {
+    } else if (name.casecmpTo(property2_name) == 0) {
         value.* = Godot.Variant.initFrom(Vec3.new(24, 24, 24));
         return true;
     }
@@ -144,10 +144,10 @@ pub fn _property_get_revert(_: *Self, name: Godot.StringName, value: *Godot.Vari
 }
 
 pub fn _set(self: *Self, name: Godot.StringName, value: Godot.Variant) bool {
-    if (name.casecmp_to(property1_name) == 0) {
+    if (name.casecmpTo(property1_name) == 0) {
         self.property1 = value.as(Vec3);
         return true;
-    } else if (name.casecmp_to(property2_name) == 0) {
+    } else if (name.casecmpTo(property2_name) == 0) {
         self.property2 = value.as(Vec3);
         return true;
     }
@@ -156,10 +156,10 @@ pub fn _set(self: *Self, name: Godot.StringName, value: Godot.Variant) bool {
 }
 
 pub fn _get(self: *Self, name: Godot.StringName, value: *Godot.Variant) bool {
-    if (name.casecmp_to(property1_name) == 0) {
+    if (name.casecmpTo(property1_name) == 0) {
         value.* = Godot.Variant.initFrom(self.property1);
         return true;
-    } else if (name.casecmp_to(property2_name) == 0) {
+    } else if (name.casecmpTo(property2_name) == 0) {
         value.* = Godot.Variant.initFrom(self.property2);
         return true;
     }

--- a/examples/with_project/src/GuiNode.zig
+++ b/examples/with_project/src/GuiNode.zig
@@ -9,19 +9,19 @@ base: Godot.Control,
 sprite: Godot.Sprite2D,
 
 pub fn _enter_tree(self: *Self) void {
-    if (Godot.Engine.getSingleton().is_editor_hint()) return;
+    if (Godot.Engine.getSingleton().isEditorHint()) return;
 
     var normal_btn = Godot.initButton();
-    self.add_child(normal_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    normal_btn.set_position(Vec2.new(100, 20), false);
-    normal_btn.set_size(Vec2.new(100, 50), false);
-    normal_btn.set_text("Press Me");
+    self.addChild(normal_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    normal_btn.setPosition(Vec2.new(100, 20), false);
+    normal_btn.setSize(Vec2.new(100, 50), false);
+    normal_btn.setText("Press Me");
 
     var toggle_btn = Godot.initCheckBox();
-    self.add_child(toggle_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    toggle_btn.set_position(Vec2.new(320, 20), false);
-    toggle_btn.set_size(Vec2.new(100, 50), false);
-    toggle_btn.set_text("Toggle Me");
+    self.addChild(toggle_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    toggle_btn.setPosition(Vec2.new(320, 20), false);
+    toggle_btn.setSize(Vec2.new(100, 50), false);
+    toggle_btn.setText("Toggle Me");
 
     Godot.connect(toggle_btn, "toggled", self, "on_toggled");
     Godot.connect(normal_btn, "pressed", self, "on_pressed");
@@ -32,10 +32,10 @@ pub fn _enter_tree(self: *Self) void {
     if (texture) |tex| {
         defer _ = Godot.unreference(tex);
         self.sprite = Godot.initSprite2D();
-        self.sprite.set_texture(tex);
-        self.sprite.set_position(Vec2.new(400, 300));
-        self.sprite.set_scale(Vec2.new(0.6, 0.6));
-        self.add_child(self.sprite, false, Godot.Node.INTERNAL_MODE_DISABLED);
+        self.sprite.setTexture(tex);
+        self.sprite.setPosition(Vec2.new(400, 300));
+        self.sprite.setScale(Vec2.new(0.6, 0.6));
+        self.addChild(self.sprite, false, Godot.Node.INTERNAL_MODE_DISABLED);
     }
 }
 

--- a/examples/with_project/src/SignalNode.zig
+++ b/examples/with_project/src/SignalNode.zig
@@ -19,31 +19,31 @@ pub fn _bind_methods() void {
 }
 
 pub fn _enter_tree(self: *Self) void {
-    if (Godot.Engine.getSingleton().is_editor_hint()) return;
+    if (Godot.Engine.getSingleton().isEditorHint()) return;
 
     var signal1_btn = Godot.initButton();
-    self.add_child(signal1_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    signal1_btn.set_position(Vec2.new(100, 20), false);
-    signal1_btn.set_size(Vec2.new(100, 50), false);
-    signal1_btn.set_text("Signal1");
+    self.addChild(signal1_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    signal1_btn.setPosition(Vec2.new(100, 20), false);
+    signal1_btn.setSize(Vec2.new(100, 50), false);
+    signal1_btn.setText("Signal1");
 
     var signal2_btn = Godot.initButton();
-    self.add_child(signal2_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    signal2_btn.set_position(Vec2.new(250, 20), false);
-    signal2_btn.set_size(Vec2.new(100, 50), false);
-    signal2_btn.set_text("Signal2");
+    self.addChild(signal2_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    signal2_btn.setPosition(Vec2.new(250, 20), false);
+    signal2_btn.setSize(Vec2.new(100, 50), false);
+    signal2_btn.setText("Signal2");
 
     var signal3_btn = Godot.initButton();
-    self.add_child(signal3_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    signal3_btn.set_position(Vec2.new(400, 20), false);
-    signal3_btn.set_size(Vec2.new(100, 50), false);
-    signal3_btn.set_text("Signal3");
+    self.addChild(signal3_btn, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    signal3_btn.setPosition(Vec2.new(400, 20), false);
+    signal3_btn.setSize(Vec2.new(100, 50), false);
+    signal3_btn.setText("Signal3");
 
     self.color_rect = Godot.initColorRect();
-    self.add_child(self.color_rect, false, Godot.Node.INTERNAL_MODE_DISABLED);
-    self.color_rect.set_position(Vec2.new(400, 400), false);
-    self.color_rect.set_size(Vec2.new(100, 100), false);
-    self.color_rect.set_color(Godot.Color.initFromF64F64F64F64(1, 0, 0, 1));
+    self.addChild(self.color_rect, false, Godot.Node.INTERNAL_MODE_DISABLED);
+    self.color_rect.setPosition(Vec2.new(400, 400), false);
+    self.color_rect.setSize(Vec2.new(100, 100), false);
+    self.color_rect.setColor(Godot.Color.initFromF64F64F64F64(1, 0, 0, 1));
 
     Godot.connect(signal1_btn, "pressed", self, "emitSignal1");
     Godot.connect(signal2_btn, "pressed", self, "emitSignal2");
@@ -64,19 +64,19 @@ pub fn onSignal1(_: *Self, name: Godot.StringName, position: Godot.Vector3) void
 }
 
 pub fn onSignal2(self: *Self) void {
-    self.color_rect.set_color(Godot.Color.initFromF64F64F64F64(0, 1, 0, 1));
+    self.color_rect.setColor(Godot.Color.initFromF64F64F64F64(0, 1, 0, 1));
 }
 
 pub fn onSignal3(self: *Self) void {
-    self.color_rect.set_color(Godot.Color.initFromF64F64F64F64(1, 0, 0, 1));
+    self.color_rect.setColor(Godot.Color.initFromF64F64F64F64(1, 0, 0, 1));
 }
 
 pub fn emitSignal1(self: *Self) void {
-    _ = self.emit_signal("signal1", .{ Godot.String.initFromLatin1Chars("test_signal_name"), Vec3.new(123, 321, 333) });
+    _ = self.emitSignal("signal1", .{ Godot.String.initFromLatin1Chars("test_signal_name"), Vec3.new(123, 321, 333) });
 }
 pub fn emitSignal2(self: *Self) void {
-    _ = self.emit_signal("signal2", .{});
+    _ = self.emitSignal("signal2", .{});
 }
 pub fn emitSignal3(self: *Self) void {
-    _ = self.emit_signal("signal3", .{});
+    _ = self.emitSignal("signal3", .{});
 }

--- a/examples/with_project/src/SpriteNode.zig
+++ b/examples/with_project/src/SpriteNode.zig
@@ -19,7 +19,7 @@ pub fn newSpritesNode() *Self {
 }
 
 pub fn _ready(self: *Self) void {
-    if (Godot.Engine.getSingleton().is_editor_hint()) return;
+    if (Godot.Engine.getSingleton().isEditorHint()) return;
 
     self.sprites = std.ArrayList(Sprite).init(Godot.general_allocator);
     const rnd = Godot.initRandomNumberGenerator();
@@ -28,20 +28,20 @@ pub fn _ready(self: *Self) void {
     const resource_loader = Godot.ResourceLoader.getSingleton();
     const tex = resource_loader.load("res://textures/logo.png", "", Godot.ResourceLoader.CACHE_MODE_REUSE);
     defer _ = Godot.unreference(tex.?);
-    const sz = self.get_parent_area_size();
+    const sz = self.getParentAreaSize();
 
     for (0..10000) |_| {
-        const s: f32 = @floatCast(rnd.randf_range(0.1, 0.2));
+        const s: f32 = @floatCast(rnd.randfRange(0.1, 0.2));
         const spr = Sprite{
-            .pos = Vec2.new(@floatCast(rnd.randf_range(0, sz.x)), @floatCast(rnd.randf_range(0, sz.y))),
-            .vel = Vec2.new(@floatCast(rnd.randf_range(-1000, 1000)), @floatCast(rnd.randf_range(-1000, 1000))),
+            .pos = Vec2.new(@floatCast(rnd.randfRange(0, sz.x)), @floatCast(rnd.randfRange(0, sz.y))),
+            .vel = Vec2.new(@floatCast(rnd.randfRange(-1000, 1000)), @floatCast(rnd.randfRange(-1000, 1000))),
             .scale = Vec2.set(s),
             .gd_sprite = Godot.initSprite2D(),
         };
-        spr.gd_sprite.set_texture(tex);
-        spr.gd_sprite.set_rotation(rnd.randf_range(0, 3.14));
-        spr.gd_sprite.set_scale(spr.scale);
-        self.add_child(spr.gd_sprite, false, Godot.Node.INTERNAL_MODE_DISABLED);
+        spr.gd_sprite.setTexture(tex);
+        spr.gd_sprite.setRotation(rnd.randfRange(0, 3.14));
+        spr.gd_sprite.setScale(spr.scale);
+        self.addChild(spr.gd_sprite, false, Godot.Node.INTERNAL_MODE_DISABLED);
         self.sprites.append(spr) catch unreachable;
     }
 }
@@ -51,11 +51,11 @@ pub fn _exit_tree(self: *Self) void {
 }
 
 pub fn _physics_process(self: *Self, delta: f64) void {
-    const sz = self.get_parent_area_size(); //get_size();
+    const sz = self.getParentAreaSize(); //get_size();
 
     for (self.sprites.items) |*spr| {
         const pos = spr.pos.add(spr.vel.scale(@floatCast(delta)));
-        const spr_size = spr.gd_sprite.get_rect().get_size().mul(spr.gd_sprite.get_scale());
+        const spr_size = spr.gd_sprite.getRect().getSize().mul(spr.gd_sprite.getScale());
 
         if (pos.x <= spr_size.x / 2) {
             spr.vel.x = @abs(spr.vel.x);
@@ -68,6 +68,6 @@ pub fn _physics_process(self: *Self, delta: f64) void {
             spr.vel.y = -@abs(spr.vel.y);
         }
         spr.pos = pos;
-        spr.gd_sprite.set_position(spr.pos);
+        spr.gd_sprite.setPosition(spr.pos);
     }
 }

--- a/src/api/Godot.zig
+++ b/src/api/Godot.zig
@@ -373,7 +373,7 @@ pub fn registerClass(comptime T: type) void {
             _ = p_userdata;
         }
         pub fn get_virtual_bind(p_userdata: ?*anyopaque, p_name: Core.C.GDExtensionConstStringNamePtr) callconv(.C) Core.C.GDExtensionClassCallVirtual {
-            const virtual_bind = @field(T, "get_virtual_" ++ parent_class_name);
+            const virtual_bind = @field(T, "getVirtual" ++ parent_class_name);
             return virtual_bind(T, p_userdata, p_name);
         }
         pub fn get_rid_bind(p_instance: Core.C.GDExtensionClassInstancePtr) callconv(.C) u64 {


### PR DESCRIPTION
Made a few updates to the binding generator.

1. **BREAKING**: The generated function names will now adhere to the [Zig style guide](https://ziglang.org/documentation/master/#Style-Guide) by switching from snake to camel case
2. Switched from General Purpose Allocator to ArenaAllocator for better performance and simplified memory management. As the binding generator runs for a couple of seconds and then exits, I don't think that using the GPA and explicitly cleaning up memory as we go is necessary. It will all get freed when the process exits. 
3. Added a dependency on the [case project](https://github.com/travisstaloch/case/tree/main?tab=readme-ov-file) which comes with snake and camel case converters OOTB.  

Fixes #11 