### PR TITLE
Update build.zig.zon to meet requirements of Zig 0.14

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "godot",
+    .name = .godot,
+    .fingerprint = 0x74a61aa48e9841ab,
     .version = "0.0.0-dev",
     .dependencies = .{
         .case = .{


### PR DESCRIPTION
Along with the other pull requests, this patch is also needed to update the build.zig.zon file according to the new format.