### PR TITLE
Zig 0.14.0 updates (Consolidated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Issue report, feature request and pull request are all welcome.
 
 ## Prerequisites
 
-1. zig 0.13
+1. zig 0.14
 2. godot 4.3
 
 ## Usage:

--- a/binding_generator/main.zig
+++ b/binding_generator/main.zig
@@ -370,10 +370,10 @@ fn generateProc(code_builder: anytype, fn_node: anytype, allocator: mem.Allocato
         var buf: [256]u8 = undefined;
         const atypes = getArgumentsTypes(fn_node, &buf);
         if (atypes.len > 0) {
-            const temp_atypes_func_name = try temp_buf.bufPrint("{s}_from_{s}", .{func_name, atypes});
+            const temp_atypes_func_name = try temp_buf.bufPrint("{s}_from_{s}", .{ func_name, atypes });
             const atypes_func_name = getZigFuncName(allocator, temp_atypes_func_name);
 
-            try code_builder.print(0, "pub fn {s}(", .{ atypes_func_name });
+            try code_builder.print(0, "pub fn {s}(", .{atypes_func_name});
         } else {
             try code_builder.print(0, "pub fn {s}(", .{zig_func_name});
         }
@@ -481,9 +481,9 @@ fn generateProc(code_builder: anytype, fn_node: anytype, allocator: mem.Allocato
         try code_builder.printLine(1, "var args:[{d}]Godot.GDExtensionConstTypePtr = undefined;", .{args.items.len});
         for (0..args.items.len) |i| {
             if (isEngineClass(arg_types.items[i])) {
-                try code_builder.printLine(1, "if(@typeInfo(@TypeOf({1s})) == .Struct) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s})); }}", .{ i, args.items[i] });
-                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .Optional) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s}.?)); }}", .{ i, args.items[i] });
-                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .Pointer) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr({1s})); }}", .{ i, args.items[i] });
+                try code_builder.printLine(1, "if(@typeInfo(@TypeOf({1s})) == .@\"struct\") {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s})); }}", .{ i, args.items[i] });
+                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .optional) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr(&{1s}.?)); }}", .{ i, args.items[i] });
+                try code_builder.printLine(1, "else if(@typeInfo(@TypeOf({1s})) == .pointer) {{ args[{0d}] = @ptrCast(Godot.getGodotObjectPtr({1s})); }}", .{ i, args.items[i] });
                 try code_builder.printLine(1, "else {{ args[{0d}] = null; }}", .{i});
             } else {
                 if ((proc_type != .Constructor or !isStringType(class_name)) and (isStringType(arg_types.items[i]))) {
@@ -716,7 +716,7 @@ fn generateMethod(class_node: anytype, code_builder: anytype, allocator: mem.All
             const temp_virtual_inherits_func_name = try std.fmt.allocPrint(allocator, "get_virtual_{s}", .{class_node.inherits});
             const virtual_inherits_func_name = getZigFuncName(allocator, temp_virtual_inherits_func_name);
 
-            try code_builder.printLine(1, "return Godot.{s}.{s}(T, p_userdata, p_name);", .{class_node.inherits, virtual_inherits_func_name});
+            try code_builder.printLine(1, "return Godot.{s}.{s}(T, p_userdata, p_name);", .{ class_node.inherits, virtual_inherits_func_name });
         } else {
             try code_builder.writeLine(1, "_ = T;");
             try code_builder.writeLine(1, "_ = p_userdata;");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.0.0-dev",
     .dependencies = .{
         .case = .{
-            .url = "git+https://github.com/travisstaloch/case#698a01886de891c03434f34e6bca95546026eb0f",
-            .hash = "12207c971fe9b4d6430503d3a4d00c6296f52b52da47c11cb8e37706e86c3ffee49e",
+            .url = "git+https://github.com/travisstaloch/case.git#57aa52a376cee0e826526972c9becc63d0d48093",
+            .hash = "case-0.0.1-chGYq3zEAACCYSlQhW6K9Gd8g93Wv8gQOIrNY7xTt8Up",
         },
     },
     .minimum_zig_version = "0.13.0",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,7 +8,7 @@
             .hash = "case-0.0.1-chGYq3zEAACCYSlQhW6K9Gd8g93Wv8gQOIrNY7xTt8Up",
         },
     },
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
 
     .paths = .{
         "LICENSE",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "godot",
+    .name = .godot,
+    .fingerprint = 0x74a61aa48e9841ab,
     .version = "0.0.0-dev",
     .dependencies = .{
         .case = .{

--- a/src/api/Godot.zig
+++ b/src/api/Godot.zig
@@ -92,10 +92,10 @@ pub fn free(ptr: ?*anyopaque) void {
 
 pub fn getGodotObjectPtr(inst: anytype) *const ?*anyopaque {
     const typeInfo = @typeInfo(@TypeOf(inst));
-    if (typeInfo != .Pointer) {
+    if (typeInfo != .pointer) {
         @compileError("pointer required");
     }
-    const T = typeInfo.Pointer.child;
+    const T = typeInfo.pointer.child;
     if (@hasField(T, "godot_object")) {
         return &inst.godot_object;
     } else if (@hasField(T, "base")) {
@@ -394,8 +394,8 @@ pub fn registerClass(comptime T: type) void {
 
 pub fn MethodBinderT(comptime MethodType: type) type {
     return struct {
-        const ReturnType = @typeInfo(MethodType).Fn.return_type;
-        const ArgCount = @typeInfo(MethodType).Fn.params.len;
+        const ReturnType = @typeInfo(MethodType).@"fn".return_type;
+        const ArgCount = @typeInfo(MethodType).@"fn".params.len;
         const ArgsTuple = std.meta.fields(std.meta.ArgsTuple(MethodType));
         var arg_properties: [ArgCount + 1]Core.C.GDExtensionPropertyInfo = undefined;
         var arg_metadata: [ArgCount + 1]Core.C.GDExtensionClassMethodArgumentMetadata = undefined;
@@ -432,7 +432,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
 
         fn ptrToArg(comptime T: type, p_arg: Core.C.GDExtensionConstTypePtr) T {
             switch (@typeInfo(T)) {
-                // .Pointer => |pointer| {
+                // .pointer => |pointer| {
                 //     const ObjectType = pointer.child;
                 //     const ObjectTypeName = comptime getBaseName(@typeName(ObjectType));
                 //     const callbacks = @field(ObjectType, "callbacks_" ++ ObjectTypeName);
@@ -443,7 +443,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
                 //         return @ptrCast(@alignCast(Core.objectGetInstanceBinding(p_arg, Core.p_library, @ptrCast(&callbacks))));
                 //     }
                 // },
-                .Struct => {
+                .@"struct" => {
                     if (@hasDecl(T, "reference") and @hasDecl(T, "unreference")) { //RefCounted
                         const obj = Core.refGetObject(p_arg);
                         return .{ .godot_object = obj };
@@ -571,7 +571,7 @@ pub fn registerSignal(comptime T: type, comptime signal_name: [:0]const u8, argu
 }
 
 pub fn connect(godot_object: anytype, signal_name: [:0]const u8, instance: anytype, comptime method_name: [:0]const u8) void {
-    if (@typeInfo(@TypeOf(instance)) != .Pointer) {
+    if (@typeInfo(@TypeOf(instance)) != .pointer) {
         @compileError("pointer type expected for parameter 'instance'");
     }
     registerMethod(std.meta.Child(@TypeOf(instance)), method_name);

--- a/src/api/Godot.zig
+++ b/src/api/Godot.zig
@@ -104,7 +104,7 @@ pub fn getGodotObjectPtr(inst: anytype) *const ?*anyopaque {
 }
 
 pub fn cast(comptime T: type, inst: anytype) ?T {
-    if (@typeInfo(@TypeOf(inst)) == .Optional) {
+    if (@typeInfo(@TypeOf(inst)) == .optional) {
         if (inst) |i| {
             return .{ .godot_object = i.godot_object };
         } else {

--- a/src/api/Variant.zig
+++ b/src/api/Variant.zig
@@ -128,14 +128,14 @@ fn getByGodotType(comptime T: type) Type {
 fn getChildTypeOrSelf(comptime T: type) type {
     const typeInfo = @typeInfo(T);
     return switch (typeInfo) {
-        .Pointer => |info| info.child,
-        .Optional => |info| info.child,
+        .pointer => |info| info.child,
+        .optional => |info| info.child,
         else => T,
     };
 }
 pub fn getVariantType(comptime T: type) Type {
     const typeInfo = @typeInfo(T);
-    if (typeInfo == .Pointer and @typeInfo(typeInfo.Pointer.child) != .Struct) {
+    if (typeInfo == .pointer and @typeInfo(typeInfo.pointer.child) != .@"struct") {
         @compileError("Init Variant from " ++ @typeName(T) ++ " is not supported");
     }
     const RT = getChildTypeOrSelf(T);
@@ -143,11 +143,11 @@ pub fn getVariantType(comptime T: type) Type {
     const ret = comptime getByGodotType(RT);
     if (ret == Godot.GDEXTENSION_VARIANT_TYPE_NIL) {
         const ret1 = switch (@typeInfo(RT)) {
-            .Struct => Godot.GDEXTENSION_VARIANT_TYPE_OBJECT,
-            .Bool => Godot.GDEXTENSION_VARIANT_TYPE_BOOL,
-            .Int, .ComptimeInt => Godot.GDEXTENSION_VARIANT_TYPE_INT,
-            .Float, .ComptimeFloat => Godot.GDEXTENSION_VARIANT_TYPE_FLOAT,
-            .Void => Godot.GDEXTENSION_VARIANT_TYPE_NIL,
+            .@"struct" => Godot.GDEXTENSION_VARIANT_TYPE_OBJECT,
+            .bool => Godot.GDEXTENSION_VARIANT_TYPE_BOOL,
+            .int, .comptime_int => Godot.GDEXTENSION_VARIANT_TYPE_INT,
+            .float, .comptime_float => Godot.GDEXTENSION_VARIANT_TYPE_FLOAT,
+            .void => Godot.GDEXTENSION_VARIANT_TYPE_NIL,
             else => @compileError("Cannot construct variant from " ++ @typeName(T)),
         };
         return ret1;

--- a/src/api/Variant.zig
+++ b/src/api/Variant.zig
@@ -178,7 +178,7 @@ pub fn as(self_const: Self, comptime T: type) T {
         var obj: ?*anyopaque = null;
         to_type[Godot.GDEXTENSION_VARIANT_TYPE_OBJECT].?(@ptrCast(&obj), @ptrCast(&self.value));
         const godotObj: *Godot.Object = @ptrCast(@alignCast(Godot.getObjectInstanceBinding(obj)));
-        const RealType = @typeInfo(T).Pointer.child;
+        const RealType = @typeInfo(T).pointer.child;
         if (RealType == Godot.Object) {
             return godotObj;
         } else {


### PR DESCRIPTION
This PR consolidates #57, #56 and #34. 

Have tested against https://github.com/godot-zig/godot-zig-examples/pull/7 with Godot 4.3. Godot 4.4.x will require separate updates. 

- **Upgrade to zig 0.14**
- **Readme 0.14**
- **Update build.zig.zon to meet requirements of Zig 0.14**
- **chore: upgrade case package**
- **build: bump minimum zig version**
- **switch type info enum variants**
- Fixes #49 
